### PR TITLE
Fix dead link in the bottom of Getting Started page

### DIFF
--- a/docs/pages/getting-started/Installation.md
+++ b/docs/pages/getting-started/Installation.md
@@ -101,6 +101,6 @@ Optionally you can enable Bash autocompletion by adding `source blueprint;` into
 <br>
 
 #### <i class="bi bi-check-circle-fill"></i> Mission complete!
-Blueprint should now be installed onto your Pterodactyl panel which means you'll be able to start installing or developing extensions. To learn more about Blueprint's command line utility, run `blueprint -help`. If you like the project, please <a href="https://github.com/blueprintframewor/main" class="text-warning-emphasis">star</a> it on GitHub.
+Blueprint should now be installed onto your Pterodactyl panel which means you'll be able to start installing or developing extensions. To learn more about Blueprint's command line utility, run `blueprint -help`. If you like the project, please <a href="https://github.com/BlueprintFramework/framework" class="text-warning-emphasis">star</a> it on GitHub.
 
 Get started with developing extensions through [this guide](?page=getting-started/Extension-development) or find new extensions on [the extension discovery list](../browse). There is so much to discover, welcome to Blueprint.


### PR DESCRIPTION
This PR fixes the star button to redirect to https://github.com/BlueprintFramework/framework instead of https://github.com/blueprintframewor/main, as blueprintframewor/main goes to nothing.