### PR TITLE
Update Ptero path placeholders | New "Upload Extensions"

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -82,11 +82,11 @@ function changethepath() { // this is used to change path in code blocks
     
     let content = block.dataset.original;
     
-    if (content.includes('/path/to/pterodactyl')) {
+    if (content.includes('/var/www/pterodactyl')) {
       if (block.innerHTML) {
-        block.innerHTML = content.replaceAll('/path/to/pterodactyl', dirPath);
+        block.innerHTML = content.replaceAll('/var/www/pterodactyl', dirPath);
       } else {
-        block.textContent = content.replaceAll('/path/to/pterodactyl', dirPath);
+        block.textContent = content.replaceAll('/var/www/pterodactyl', dirPath);
       }
     }
   });

--- a/docs/pages/getting-started/Installation.md
+++ b/docs/pages/getting-started/Installation.md
@@ -12,8 +12,9 @@ Want to run Blueprint through Docker instead? Take a peek at the official <a hre
   <div class="bg-body rounded-3 p-3 mb-3">
     <h5><i class="bi bi-folder2-open"></i> What's your Pterodactyl path?</h5>
     <p class="mb-2 text-secondary"><small>We'll update the commands below to work for your specific installation</small></p>
+    <p class="mb-2 text-secondary"><small>But if you didn't change the default Pterodactyl installation path, you don't need to change it here</small></p>
     <div class="input-group mb-3">
-      <input type="text" id="dirPath" class="form-control" placeholder="/path/to/pterodactyl" aria-label="Pterodactyl path" oninput="changethepath()">
+      <input type="text" id="dirPath" class="form-control" placeholder="/var/www/pterodactyl" aria-label="Pterodactyl default path" oninput="changethepath()">
     </div>
   </div>
 
@@ -41,7 +42,7 @@ apt-get install -y nodejs</code></pre>
       <p>Pterodactyl uses Yarn for managing it's node modules, which we'll need to install as well.</p>
       <pre><code class="language-bash">npm i -g yarn</code></pre>
       <p>Navigate to your Pterodactyl (usually <code>/var/www/pterodactyl</code>) and run the following command to initialize dependencies:</p>
-      <pre><code class="ptero-cmd language-bash">cd /path/to/pterodactyl
+      <pre><code class="ptero-cmd language-bash">cd /var/www/pterodactyl #Default pterodactyl path
 yarn</code></pre>
     </div>
     <!-- Additional dependencies -->
@@ -74,8 +75,8 @@ wget "$(curl -s https://api.github.com/repos/BlueprintFramework/framework/releas
 Unarchive the release you downloaded in the previous step in your Pterodactyl folder.
 
 ```bash
-mv release.zip /path/to/pterodactyl/release.zip
-cd /path/to/pterodactyl
+mv release.zip /var/www/pterodactyl/release.zip
+cd /var/www/pterodactyl  #Default pterodactyl path
 unzip release.zip
 ```
 
@@ -87,7 +88,7 @@ unzip release.zip
 This step allows Blueprint to function and know where itself and Pterodactyl are located and which permissions to use. Create a file called `.blueprintrc` inside of your Pterodactyl directory to begin.
 
 ```bash
-touch /path/to/pterodactyl/.blueprintrc
+touch /var/www/pterodactyl/.blueprintrc
 ```
 
 Modify the `$WEBUSER`, `$USERSHELL` and `$PERMISSIONS` values to match your environment. Provided below is the standard configuration for Debian-based systems, but you might need to make your own modifications.
@@ -96,7 +97,7 @@ Modify the `$WEBUSER`, `$USERSHELL` and `$PERMISSIONS` values to match your envi
 echo \
 'WEBUSER="www-data";
 OWNERSHIP="www-data:www-data";
-USERSHELL="/bin/bash";' >> /path/to/pterodactyl/.blueprintrc
+USERSHELL="/bin/bash";' >> /var/www/pterodactyl/.blueprintrc
 ```
 
 <br>

--- a/docs/pages/getting-started/Managing-extensions.md
+++ b/docs/pages/getting-started/Managing-extensions.md
@@ -20,6 +20,29 @@
   <div class="ps-3 ms-3">Blueprint extensions must be installed, updated, built and removed via the command line. Shell access is required to perform these actions.</div>
 </div><br/>
 
+### **Upload Extensions**
+
+<div class="alert mt-2 rounded-4 border" role="alert">
+  <i class="bi bi-exclamation-diamond mb-1 text-info float-start fs-4"></i>
+  <div class="ps-3 ms-3">Before wanting to install any blueprint extensions, you first need to upload the files to your server where Blueprint is installed on by using an SFTP client program.</div>
+</div><br/>
+
+Before wanting to install any blueprint extensions you need to upload them to your server where your pterodactyl panel with blueprint is running on.<br>
+
+For that you can use a software called <strong><a href="https://winscp.net/eng/index.php">WinSCP</a></strong>.
+<br>
+<br>
+If it is your first time using these kind of tools (SFTP clients), fear not! I will guide you through the connection process to your server. <strong><i>These steps are not including the WinSCP installation process, only the connection process</i></strong><br>
+<br>
+On the main window named "Login" with an lock icon, you will select "New Site" with File protocol set to SFTP and port number to 22, (It should be the default values, if they aren't you can just put them manually its okay), the "Host name:" text zone is your server public IP, for your username you will enter "root".<br>
+<br>
+Now that you are halfway through it you just need to either enter your root user password or if you have an SSH key you can click on "Advanced...", in the SSH section select "Authentication", and choose your SSH private key in the "Authentication parameters" (An SSH key is a file ending most of the time by .ppk) once you have finished selecting your SSH key you can back out by clicking on "Ok" and "Login" (third button starting from far down right)
+<br>
+an SSH key is a lot more secure than a simple password and is preferred but will still work<br>
+<br>
+You can click on this link to <a href="https://winscp.net/download/files/20250511150014dcc4e6cb3ecdb410d0a1017fffe9ad/WinSCP-6.5.1-Setup.exe">download WinSCP 6.5.1 Setup</a> directly. (Directly meaning that it will immediately download the installer)
+<br>
+
 ### **Install Exstensions**
 
 <div class="alert mt-2 rounded-4 border" role="alert">


### PR DESCRIPTION
Fix: update Pterodactyl path references in code and documentation, so the default placeholder is the actual default pterodactyl path for ease of installation from the end-user.
New: New upload section explaining to the user how to prepare for installation

If it needs any modifications let me know, it's my first time doing any real HTML work, so there might be some issues in the code formatting or how I formatted it on the frontend.