### PR TITLE
fix: update Pterodactyl path references in code and documentation

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -82,11 +82,11 @@ function changethepath() { // this is used to change path in code blocks
     
     let content = block.dataset.original;
     
-    if (content.includes('/path/to/pterodactyl')) {
+    if (content.includes('/var/www/pterodactyl')) {
       if (block.innerHTML) {
-        block.innerHTML = content.replaceAll('/path/to/pterodactyl', dirPath);
+        block.innerHTML = content.replaceAll('/var/www/pterodactyl', dirPath);
       } else {
-        block.textContent = content.replaceAll('/path/to/pterodactyl', dirPath);
+        block.textContent = content.replaceAll('/var/www/pterodactyl', dirPath);
       }
     }
   });

--- a/docs/pages/getting-started/Installation.md
+++ b/docs/pages/getting-started/Installation.md
@@ -12,8 +12,9 @@ Want to run Blueprint through Docker instead? Take a peek at the official <a hre
   <div class="bg-body rounded-3 p-3 mb-3">
     <h5><i class="bi bi-folder2-open"></i> What's your Pterodactyl path?</h5>
     <p class="mb-2 text-secondary"><small>We'll update the commands below to work for your specific installation</small></p>
+    <p class="mb-2 text-secondary"><small>But if you didn't change the default Pterodactyl installation path, you don't need to change it here</small></p>
     <div class="input-group mb-3">
-      <input type="text" id="dirPath" class="form-control" placeholder="/path/to/pterodactyl" aria-label="Pterodactyl path" oninput="changethepath()">
+      <input type="text" id="dirPath" class="form-control" placeholder="/var/www/pterodactyl" aria-label="Pterodactyl default path" oninput="changethepath()">
     </div>
   </div>
 
@@ -41,7 +42,7 @@ apt-get install -y nodejs</code></pre>
       <p>Pterodactyl uses Yarn for managing it's node modules, which we'll need to install as well.</p>
       <pre><code class="language-bash">npm i -g yarn</code></pre>
       <p>Navigate to your Pterodactyl (usually <code>/var/www/pterodactyl</code>) and run the following command to initialize dependencies:</p>
-      <pre><code class="ptero-cmd language-bash">cd /path/to/pterodactyl
+      <pre><code class="ptero-cmd language-bash">cd /var/www/pterodactyl #Default pterodactyl path
 yarn</code></pre>
     </div>
     <!-- Additional dependencies -->
@@ -74,8 +75,8 @@ wget "$(curl -s https://api.github.com/repos/BlueprintFramework/framework/releas
 Unarchive the release you downloaded in the previous step in your Pterodactyl folder.
 
 ```bash
-mv release.zip /path/to/pterodactyl/release.zip
-cd /path/to/pterodactyl
+mv release.zip /var/www/pterodactyl/release.zip
+cd /var/www/pterodactyl  #Default pterodactyl path
 unzip release.zip
 ```
 
@@ -87,7 +88,7 @@ unzip release.zip
 This step allows Blueprint to function and know where itself and Pterodactyl are located and which permissions to use. Create a file called `.blueprintrc` inside of your Pterodactyl directory to begin.
 
 ```bash
-touch /path/to/pterodactyl/.blueprintrc
+touch /var/www/pterodactyl/.blueprintrc
 ```
 
 Modify the `$WEBUSER`, `$USERSHELL` and `$PERMISSIONS` values to match your environment. Provided below is the standard configuration for Debian-based systems, but you might need to make your own modifications.
@@ -96,7 +97,7 @@ Modify the `$WEBUSER`, `$USERSHELL` and `$PERMISSIONS` values to match your envi
 echo \
 'WEBUSER="www-data";
 OWNERSHIP="www-data:www-data";
-USERSHELL="/bin/bash";' >> /path/to/pterodactyl/.blueprintrc
+USERSHELL="/bin/bash";' >> /var/www/pterodactyl/.blueprintrc
 ```
 
 <br>

--- a/docs/pages/getting-started/Managing-extensions.md
+++ b/docs/pages/getting-started/Managing-extensions.md
@@ -20,6 +20,32 @@
   <div class="ps-3 ms-3">Blueprint extensions must be installed, updated, built and removed via the command line. Shell access is required to perform these actions.</div>
 </div><br/>
 
+### **Upload Extensions**
+
+<div class="alert mt-2 rounded-4 border" role="alert">
+  <i class="bi bi-exclamation-diamond mb-1 text-info float-start fs-4"></i>
+  <div class="ps-3 ms-3">Before wanting to install any blueprint extensions, you first need to upload the files to your server where Blueprint is installed on by using an SFTP client program.</div>
+</div><br/>
+
+<details class="mb-3">
+  <summary class="fw-bold cursor-pointer">
+    <i class=Upload-Dropdown></i> How to upload extensions using SFTP clients (Only if you don't know already know that.)
+  </summary>
+  <div class="ps-3 pt-3">
+<p>Before wanting to install any blueprint extensions you need to upload them to your server where your pterodactyl panel with blueprint is running on.</p>
+
+<p>For that you can use a software called <strong><a href="https://filezilla-project.org/">FileZilla</a></strong>.</p>
+
+<p>If it is your first time using these kind of tools (SFTP clients), bellow is a simple guide of the connection process to your remote server. <strong><i>These steps are not including the installation process of FileZilla on your platform, only the connection process.</i></strong></p>
+
+<p>On the main window you will see a file manager, now fill the information needed in the "Host:your-server-IP", "Username:root" "Password:your-root-user-password", "Port:22" and click "Quickconnect".</p>
+<p>Welcome to your remote server storage, now go over your pterodactyl path (default: /path/to/pterodactyl) and upload your extension file and enjoy your new extension!.
+
+<p>An SSH key is a lot more secure and is preferred over a simple password but will still work with an password</p>
+
+  </div>
+</details>
+
 ### **Install Exstensions**
 
 <div class="alert mt-2 rounded-4 border" role="alert">


### PR DESCRIPTION
Fix: update Pterodactyl path references in code and documentation, so the default placeholder is the actual default pterodactyl path for ease of installation from the end-user.

If it needs any modifications let me know, it's my first time doing any real HTML work, so there might be some issues in the code formatting or how I formatted it on the frontend.