### PR TITLE
Update default ptero path

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -82,11 +82,11 @@ function changethepath() { // this is used to change path in code blocks
     
     let content = block.dataset.original;
     
-    if (content.includes('/path/to/pterodactyl')) {
+    if (content.includes('/var/www/pterodactyl')) {
       if (block.innerHTML) {
-        block.innerHTML = content.replaceAll('/path/to/pterodactyl', dirPath);
+        block.innerHTML = content.replaceAll('/var/www/pterodactyl', dirPath);
       } else {
-        block.textContent = content.replaceAll('/path/to/pterodactyl', dirPath);
+        block.textContent = content.replaceAll('/var/www/pterodactyl', dirPath);
       }
     }
   });

--- a/docs/pages/getting-started/Installation.md
+++ b/docs/pages/getting-started/Installation.md
@@ -42,7 +42,7 @@ apt-get install -y nodejs</code></pre>
       <p>Pterodactyl uses Yarn for managing it's node modules, which we'll need to install as well.</p>
       <pre><code class="language-bash">npm i -g yarn</code></pre>
       <p>Navigate to your Pterodactyl (usually <code>/var/www/pterodactyl</code>) and run the following command to initialize dependencies:</p>
-      <pre><code class="ptero-cmd language-bash">cd /var/www/pterodactyl #Default pterodactyl path
+      <pre><code class="ptero-cmd language-bash">cd /var/www/pterodactyl
 yarn</code></pre>
     </div>
     <!-- Additional dependencies -->
@@ -76,7 +76,7 @@ Unarchive the release you downloaded in the previous step in your Pterodactyl fo
 
 ```bash
 mv release.zip /var/www/pterodactyl/release.zip
-cd /var/www/pterodactyl  #Default pterodactyl path
+cd /var/www/pterodactyl
 unzip release.zip
 ```
 

--- a/docs/pages/getting-started/Installation.md
+++ b/docs/pages/getting-started/Installation.md
@@ -12,8 +12,9 @@ Want to run Blueprint through Docker instead? Take a peek at the official <a hre
   <div class="bg-body rounded-3 p-3 mb-3">
     <h5><i class="bi bi-folder2-open"></i> What's your Pterodactyl path?</h5>
     <p class="mb-2 text-secondary"><small>We'll update the commands below to work for your specific installation</small></p>
+    <p class="mb-2 text-secondary"><small>But if you didn't change the default Pterodactyl installation path, you don't need to change it here</small></p>
     <div class="input-group mb-3">
-      <input type="text" id="dirPath" class="form-control" placeholder="/path/to/pterodactyl" aria-label="Pterodactyl path" oninput="changethepath()">
+      <input type="text" id="dirPath" class="form-control" placeholder="/var/www/pterodactyl" aria-label="Pterodactyl default path" oninput="changethepath()">
     </div>
   </div>
 
@@ -41,7 +42,7 @@ apt-get install -y nodejs</code></pre>
       <p>Pterodactyl uses Yarn for managing it's node modules, which we'll need to install as well.</p>
       <pre><code class="language-bash">npm i -g yarn</code></pre>
       <p>Navigate to your Pterodactyl (usually <code>/var/www/pterodactyl</code>) and run the following command to initialize dependencies:</p>
-      <pre><code class="ptero-cmd language-bash">cd /path/to/pterodactyl
+      <pre><code class="ptero-cmd language-bash">cd /var/www/pterodactyl #Default pterodactyl path
 yarn</code></pre>
     </div>
     <!-- Additional dependencies -->
@@ -74,8 +75,8 @@ wget "$(curl -s https://api.github.com/repos/BlueprintFramework/framework/releas
 Unarchive the release you downloaded in the previous step in your Pterodactyl folder.
 
 ```bash
-mv release.zip /path/to/pterodactyl/release.zip
-cd /path/to/pterodactyl
+mv release.zip /var/www/pterodactyl/release.zip
+cd /var/www/pterodactyl  #Default pterodactyl path
 unzip release.zip
 ```
 
@@ -87,7 +88,7 @@ unzip release.zip
 This step allows Blueprint to function and know where itself and Pterodactyl are located and which permissions to use. Create a file called `.blueprintrc` inside of your Pterodactyl directory to begin.
 
 ```bash
-touch /path/to/pterodactyl/.blueprintrc
+touch /var/www/pterodactyl/.blueprintrc
 ```
 
 Modify the `$WEBUSER`, `$USERSHELL` and `$PERMISSIONS` values to match your environment. Provided below is the standard configuration for Debian-based systems, but you might need to make your own modifications.
@@ -96,7 +97,7 @@ Modify the `$WEBUSER`, `$USERSHELL` and `$PERMISSIONS` values to match your envi
 echo \
 'WEBUSER="www-data";
 OWNERSHIP="www-data:www-data";
-USERSHELL="/bin/bash";' >> /path/to/pterodactyl/.blueprintrc
+USERSHELL="/bin/bash";' >> /var/www/pterodactyl/.blueprintrc
 ```
 
 <br>


### PR DESCRIPTION
This pull request updates the default Pterodactyl installation path in the documentation and associated scripts to reflect the correct directory (`/var/www/pterodactyl`). The changes ensure consistency across examples and instructions, making the setup process clearer for users.

### Updates to default Pterodactyl path:

* [`docs/index.js`](diffhunk://#diff-c562fb846f34de0bd255222a1e312f9f07dee217c353136f78377e1f9d324b37L85-R89): Updated the `changethepath` function to replace occurrences of `/path/to/pterodactyl` with `/var/www/pterodactyl` in code blocks dynamically.