### PR TITLE
Add price filter to extension/theme browse page

### DIFF
--- a/apps/frontend/src/components/ui/browse/Filters.vue
+++ b/apps/frontend/src/components/ui/browse/Filters.vue
@@ -27,6 +27,36 @@
       </button>
     </div>
   </div>
+
+  <div
+    class="divide-y divide-neutral-700 rounded-2xl border border-neutral-700 transition-colors focus-within:divide-neutral-500 focus-within:border-neutral-500"
+  >
+    <div class="flex items-center gap-1.5 p-2 font-bold transition-colors">
+      <Icon
+        name="memory:cash"
+        :size="22"
+        mode="svg"
+        class="block"
+      />
+      <span>Price</span>
+    </div>
+    <div class="space-y-2 p-2 transition-colors">
+      <button
+        v-for="priceOption in priceOptions"
+        :key="priceOption.value"
+        class="hover:text-brand-50 focus:text-brand-50 text-default-font/60 block w-full cursor-pointer text-start outline-0 transition-colors focus:font-bold"
+        tabindex="0"
+        :class="{
+          '!text-default-font': props.form.priceFilter === priceOption.value,
+        }"
+        @click="props.form.priceFilter = priceOption.value"
+        @mousedown.prevent
+      >
+        <span>{{ priceOption.label }}</span>
+      </button>
+    </div>
+  </div>
+
   <div class="group">
     <button
       class="focus:text-brand-50 hover:text-brand-50 w-full cursor-pointer rounded-t-2xl border border-neutral-700 p-2 outline-0 transition-colors group-focus-within:border-neutral-500"
@@ -81,6 +111,7 @@ const props = defineProps<{
     sortBy: string
     showExtensions: boolean
     showThemes: boolean
+    priceFilter: string
   }
 }>()
 
@@ -88,5 +119,11 @@ const sortOptions = [
   { value: 'popularity', label: 'Most Popular' },
   { value: 'name', label: 'Name (A-Z)' },
   { value: 'created', label: 'Newest First' },
+]
+
+const priceOptions = [
+  { value: 'all', label: 'All Prices' },
+  { value: 'free', label: 'Free Only' },
+  { value: 'premium', label: 'Premium Only' },
 ]
 </script>

--- a/apps/frontend/src/components/ui/browse/Filters.vue
+++ b/apps/frontend/src/components/ui/browse/Filters.vue
@@ -40,20 +40,19 @@
       />
       <span>Price</span>
     </div>
-    <div class="space-y-2 p-2 transition-colors">
-      <button
-        v-for="priceOption in priceOptions"
-        :key="priceOption.value"
-        class="hover:text-brand-50 focus:text-brand-50 text-default-font/60 block w-full cursor-pointer text-start outline-0 transition-colors focus:font-bold"
-        tabindex="0"
-        :class="{
-          '!text-default-font': props.form.priceFilter === priceOption.value,
-        }"
-        @click="props.form.priceFilter = priceOption.value"
-        @mousedown.prevent
-      >
-        <span>{{ priceOption.label }}</span>
-      </button>
+    <div class="space-y-3 p-4 transition-colors">
+      <input
+        type="range"
+        min="0"
+        max="1000"
+        step="1000"
+        v-model.number="props.form.maxPrice"
+        class="slider block w-full rounded-lg appearance-none cursor-pointer"
+      />
+      <div class="flex justify-between text-xs text-default-font/40">
+        <span>Free</span>
+        <span>Paid</span>
+      </div>
     </div>
   </div>
 
@@ -111,7 +110,7 @@ const props = defineProps<{
     sortBy: string
     showExtensions: boolean
     showThemes: boolean
-    priceFilter: string
+    maxPrice: number
   }
 }>()
 
@@ -120,10 +119,55 @@ const sortOptions = [
   { value: 'name', label: 'Name (A-Z)' },
   { value: 'created', label: 'Newest First' },
 ]
-
-const priceOptions = [
-  { value: 'all', label: 'All Prices' },
-  { value: 'free', label: 'Free Only' },
-  { value: 'premium', label: 'Premium Only' },
-]
 </script>
+
+<style scoped>
+.slider {
+  background: white;
+  height: 6px;
+  border-radius: 999px;
+}
+
+.slider::-webkit-slider-runnable-track {
+  background: white;
+  height: 6px;
+  border-radius: 999px;
+}
+
+.slider::-moz-range-track {
+  background: white;
+  height: 6px;
+  border-radius: 999px;
+}
+
+.slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #6db7ff;
+  cursor: pointer;
+  border: 2px solid #6db7ff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  margin-top: -6px;
+}
+
+.slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #6db7ff;
+  cursor: pointer;
+  border: 2px solid #6db7ff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  margin-top: -6px;
+}
+
+.slider::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+}
+
+.slider::-moz-range-thumb:hover {
+  transform: scale(1.1);
+}
+</style>

--- a/apps/frontend/src/pages/browse/index.vue
+++ b/apps/frontend/src/pages/browse/index.vue
@@ -151,7 +151,7 @@ const form = ref({
   sortBy: 'popularity',
   showExtensions: true,
   showThemes: true,
-  priceFilter: 'all',
+  maxPrice: 0,
 })
 
 const getMinPrice = (extension: Extension): number => {
@@ -191,15 +191,12 @@ const filteredAndSortedExtensions = computed(() => {
   })
 
   filtered = filtered.filter((extension) => {
-    switch (form.value.priceFilter) {
-      case 'free':
-        return isFree(extension)
-      case 'premium':
-        return !isFree(extension)
-      case 'all':
-      default:
-        return true
+    const minPrice = getMinPrice(extension)
+    if (form.value.maxPrice === 0) {
+      return minPrice === 0
     }
+    // any non-zero becomes paid-only
+    return minPrice > 0
   })
 
   switch (form.value.sortBy) {

--- a/apps/frontend/src/pages/browse/index.vue
+++ b/apps/frontend/src/pages/browse/index.vue
@@ -151,7 +151,19 @@ const form = ref({
   sortBy: 'popularity',
   showExtensions: true,
   showThemes: true,
+  priceFilter: 'all',
 })
+
+const getMinPrice = (extension: Extension): number => {
+  const prices = Object.values(extension.platforms)
+    .map(p => p.price)
+    .filter(p => p >= 0)
+  return prices.length > 0 ? Math.min(...prices) : 0
+}
+
+const isFree = (extension: Extension): boolean => {
+  return getMinPrice(extension) === 0
+}
 
 const filteredAndSortedExtensions = computed(() => {
   if (!extensions.value) return []
@@ -176,6 +188,18 @@ const filteredAndSortedExtensions = computed(() => {
       return false
     if (extension.type === 'theme' && !form.value.showThemes) return false
     return true
+  })
+
+  filtered = filtered.filter((extension) => {
+    switch (form.value.priceFilter) {
+      case 'free':
+        return isFree(extension)
+      case 'premium':
+        return !isFree(extension)
+      case 'all':
+      default:
+        return true
+    }
   })
 
   switch (form.value.sortBy) {


### PR DESCRIPTION
feat: Add price filter to extension/theme browse page

## Description
Added a new price range filter to the `/browse` page to improve the user experience when discovering extensions and themes.

## Changes
- **Component**: `src/components/ui/browse/Filters.vue`
  - Added new "Price" filter card with 3 options
  - Maintains consistent styling with existing filters

- **Page**: `src/pages/browse/index.vue`
  - Added `priceFilter` state property
  - Implemented helper functions: `getMinPrice()` and `isFree()`
  - Added filtering logic that works with existing search and type filters

## Filter Options
- **All Prices** - Shows all extensions and themes
- **Free Only** - Shows only free products (price = 0)
- **Premium Only** - Shows only paid products (price > 0)

## Implementation Details
- Uses existing `Extension.platforms[].price` data
- No backend API changes required
- Integrates seamlessly with current sort and type filters
- Maintains full responsive design

## Testing Status
:white_check_mark: Frontend tested and working locally on http://localhost:3000/browse
:warning: Unable to verify with live API data (backend not running), but filtering logic is sound

## Notes
The filter uses the minimum price across all platforms to determine if an extension is free or premium. This approach handles multi-platform pricing correctly.

<img width="381" height="172" alt="image" src="https://github.com/user-attachments/assets/8771df4c-0ef7-4787-8c84-ea140aacddc1" />
